### PR TITLE
add an /organizers url for use in top level nav and use it

### DIFF
--- a/ainow/templates/ainow/_nav.html
+++ b/ainow/templates/ainow/_nav.html
@@ -1,3 +1,4 @@
 <li {% if schedule.slug == '2016' and not is_homepage %}class="active"{% endif %}><a href="{% url 'schedule' '2016' %}">2016</a></li>
+<li {% if request.resolver_match.url_name == 'overall-organisers' %}class="active"{% endif %}><a href="{% url 'overall-organisers' %}">Organizers</a></li>
 <li><a href="{% url 'resources' %}">Resources</a></li>
 <li><a href="https://lists.princeton.edu/cgi-bin/wa?SUBED1=fatml&A=1">Mailing list</a></li>

--- a/ainow/templates/ainow/_workshop-nav.html
+++ b/ainow/templates/ainow/_workshop-nav.html
@@ -2,6 +2,5 @@
 <li><a href="{% url 'page' schedule.slug 'attend' %}">Attend</a></li>
 <li><a href="{% url 'schedule' schedule.slug %}">Schedule</a></li>
 <li><a href="{% url 'page' schedule.slug 'papers' %}">Papers</a></li>
-<li><a href="{% url 'organisers' schedule.slug %}">Organizers</a></li>
 <!-- <li><a href="{% url 'attendees' schedule.slug %}">Attendees</a></li>
 <li><a href="{% url 'speakers' schedule.slug %}">Speakers</a></li> -->

--- a/conference/urls.py
+++ b/conference/urls.py
@@ -20,6 +20,7 @@ from .views import (
     SpeakerListView,
     SpeakerView,
     OrganiserTypeListView,
+    OverallOrganiserTypeListView,
     PresentationListView,
     PresentationView,
     AttendeeListView,
@@ -40,4 +41,5 @@ urlpatterns = [
     url(r'^schedule/(?P<schedule_slug>[-\w]+)/attendee/(?P<slug>[-\w]+)$', AttendeeView.as_view(), name='attendee'),
     url(r"^profile/$", AttendeeCreateUpdateView.as_view(), name="profile"),
     url(r"^profile/delete-photo$", delete_photo, name="profile_delete_photo"),
+    url(r'^organizers$', OverallOrganiserTypeListView.as_view(), name='overall-organisers'),
 ]

--- a/conference/views.py
+++ b/conference/views.py
@@ -119,7 +119,7 @@ class SpeakerView(ScheduleMixin, DetailView):
         ).distinct()
 
 
-class OrganiserTypeListView(ScheduleMixin, ListView):
+class OverallOrganiserTypeListView(ListView):
     model = OrganiserType
     context_object_name = 'organiser_types'
 
@@ -128,6 +128,16 @@ class OrganiserTypeListView(ScheduleMixin, ListView):
         Speakers are linked to a schedule by their presentation(s) slot(s).
         """
 
+        return OrganiserType.objects.all()
+
+
+class OrganiserTypeListView(ScheduleMixin, OverallOrganiserTypeListView):
+    def get_queryset(self):
+        """
+        Exactly the same code as OverallOrganiserTypeListView but we can't
+        do super as it then inherits from the Mixin which looks for a schedule
+        which isn't something that's set on organiser_types
+        """
         return OrganiserType.objects.all()
 
 


### PR DESCRIPTION
This is currently exactly the same as /schedule/<slug>/organizers but is
there for forward compatability with schedule specific lists of
organizers.

This also removed the Organizers link from the schedule nav.