### PR TITLE
Removal of event details from homepage hero image

### DIFF
--- a/ainow/templates/ainow/_post-event-hero.html
+++ b/ainow/templates/ainow/_post-event-hero.html
@@ -1,11 +1,5 @@
 {% load staticfiles %}
-<p class="homepage-hero__details">November 18th 2016 <span class="homepage-hero__details__divider">/</span> New York University, NYC</p>
 <p class="homepage-hero__subtitle">
   Fairness, Accountability, and Transparency <span class="homepage-hero__subtitle__theme">in Machine Learning</span>
 </p>
-<p class="homepage-hero__details">
-  Co-located with the <a href="http://dtlconferences.org/">Data Transparency Lab Conference</a> and the <a href="http://datworkshop.org/">Workshop on Data and Algorithmic Transparency</a>
-</p>
-<p class="homepage-hero__details">
-The workshop is now over but a recording of the event will be available later.
-</p>
+


### PR DESCRIPTION
As per Solon's request - the removal of the extra words from the hero image