### PR TITLE
Add privacy policy page

### DIFF
--- a/ainow/templates/ainow/base.html
+++ b/ainow/templates/ainow/base.html
@@ -107,6 +107,7 @@
                 <nav class="mysoc-footer__links">
                     <ul>
                         <li role="presentation"><a href="/">About</a></li>
+                        <li role="presentation"><a href="{% url 'privacy' %}">Privacy</a></li>
                         <li role="presentation"><a href="https://www.mysociety.org/research/">Research at mySociety</a></li>
                         <li role="presentation"><a href="https://groups.google.com/forum/?hl=en#%21forum/tictecbymysociety">TICTeC Google Group</a></li>
                     </ul>

--- a/ainow/templates/ainow/privacy.html
+++ b/ainow/templates/ainow/privacy.html
@@ -1,0 +1,177 @@
+{% extends 'ainow/base.html' %}
+{% load staticfiles %}
+
+{% block title %}Privacy policy{% endblock %}
+
+{% block content %}
+<div class="general-content">
+  <div class="container standard-layout standard-layout--narrow">
+    <div class="general-content__page">
+      <div class="row">
+        <div class="standard-layout__primary-column">
+
+<h1>Privacy policy</h1>
+
+<p>Registration for TICTeC does, of course, mean that we process some of your
+personal data. Here’s a rundown of what we do with it, what that means for you,
+and what rights you have.</p>
+
+<h2 id="data">What we collect</h2>
+
+<p>Registration for TICTeC is via the third-party site Eventbrite.</p>
+
+<p>When you register, we collect the following personal information:</p>
+<ul>
+  <li>Your name</li>
+  <li>Your email address</li>
+  <li>Your job title and organisation</li>
+  <li>Your country of residence</li>
+  <li>Your billing address and some payment details (if you are a fee-paying attendee)</li>
+</ul>
+<p>See <a href="https://www.eventbrite.co.uk/support/articles/en_US/Troubleshooting/eventbrite-privacy-policy?lg=en_GB">Eventbrite’s
+Privacy Policies.</a></p>
+
+<p>You’ll also be invited to add as much detail as you like to your
+publicly-visible profile page on the TICTeC website.</p>
+
+<p>During the conference, unless you have opted out, we may take photographs and
+videos which you appear in. Opt-out is offered during the registration process.</p>
+
+<h2 id="use">How we use your data</h2>
+
+<p>If you give consent, your name, job title and organisation will appear on the
+TICTeC website (and in some cases, on print materials at the conference). This
+enables other attendees to find potentially useful contacts ahead of the event.</p>
+
+<p>Your name and email address are added to a) our Mailchimp Research newsletter
+list and b) the TICTeC Google Group. Newsletters are sent infrequently and only
+contain information about Civic Tech research. The small Google Group is a tight
+community of people who have an interest in this field. Opting out from either
+of these is very simple and you may do so at any time via a link in every mailing.</p>
+
+<p>Note that Mailchimp may transfer personal data outside the EU. Please
+<a href="https://mailchimp.com/contact">contact Mailchimp</a> with questions or
+concerns about this.</p>
+
+<p>We never use your email address for any other purpose except for those listed
+above, and to contact you with logistical information about the conference, such
+as details of travel grants or accommodation options. We will never pass your
+email address to a third party.</p>
+
+<p>Your name, email address, title, organisation, country of residence and event
+preferences (e.g. regarding catering and photography) are added to a spreadsheet
+which is accessible to mySociety staff, in accordance with their strict password
+protocols. This spreadsheet is used for planning the event.</p>
+
+<p>Your billing information is processed through Eventbrite. Your name, email
+address, the billing address of your card and the last few digits of your card
+or bank account number are made available to us along with your purchase history.</p>
+
+<p>Images and videos of the conference are uploaded to Flickr and shared via
+media including Facebook, Twitter, our website, blog and newsletter. They may
+also be used to promote future events. Images are released under a Creative
+Commons licence, so others may use them too.</p>
+
+<p>Where delegates have opted out of photography and videos, they may be
+captured on film during the conference, but will be removed before any footage
+is published.</p>
+
+<h2 id="retention">Retention period</h2>
+
+<p><strong>Web pages:</strong> At the moment, attendee pages for previous TICTeC
+conferences are kept live indefinitely: <a href="http://tictec.mysociety.org/2017/attendees">see
+this page for an example</a>. This is to prolong the period for which such lists
+can be useful for attendees’ networking and sharing of research projects. As
+time goes on, we may make the decision to retire the older attendee pages but
+currently we have no plans to do so.</p>
+
+<p><strong>Financial data:</strong> We are obliged to keep records relating to
+financial transactions for at least six years following the end of the
+accounting period in which the transaction took place. We destroy our records
+after this point.</p>
+
+<p>If you require further information on Eventbrite’s retention policies,
+please <a href="https://www.eventbrite.co.uk/support/articles/en_US/Troubleshooting/eventbrite-privacy-policy?lg=en_GB">contact
+them directly.</a></p>
+
+<p><strong>Admin data:</strong> We keep spreadsheets of attendees for the
+purposes of an audit trail and to keep track of who has attended previous
+events. Information which is surplus to these needs, e.g. dietary requirements,
+is deleted after each event.</p>
+
+<h2 id="law">Lawful basis</h2>
+
+<p>Our lawful basis for collecting and processing this information is for the
+performance of a contract to which you are party: the contract to attend TICTeC.</p>
+
+<h2 id="access">Your right to access</h2>
+
+<p>You may contact us at any time to ask to see what personal data we hold about
+you. Please <a href="mailto:tictec@mysociety.org">contact us</a> to request this.</p>
+
+<h2 id="erasure">Your right to erasure</h2>
+
+<p><strong>Web pages:</strong> With the exception of speakers, you may opt to
+remove your information from the TICTeC website at any time: just
+<a href="mailto:tictec@mysociety.org">contact us</a> to request this. Speakers
+may request removal after the event has taken place. Please note that in such
+cases, all data such as slides, video, audio, and your bio page will be removed
+from the site and from our third party pages such as the mySociety YouTube
+channel. Alternatively you may request that we anonymise your information; in
+such cases we will discuss with you how best this might be achieved.</p>
+
+<p><strong>Financial data:</strong> As per the retention period, we cannot
+legally destroy records of financial transactions for a period of six years.</p>
+
+<p><strong>Admin data:</strong> Once the conference is over, you may request
+that we destroy the data we hold in our internal documents and/or
+correspondence, provided that there is no legitimate reason for us continuing
+to hold it, that is to say if it does not relate to financial transactions or
+is unlikely to be of any legal or practical purpose in the future. Please
+<a href="mailto:tictec@mysociety.org">contact us</a> to request this.</p>
+
+<p><strong>Newsletter:</strong> When you unsubscribe from a newsletter managed
+via Mailchimp, your details remain on the list of past recipients. This is a
+measure to prevent circumstances such as a member of staff accidentally manually
+re-adding you. Mailchimp states: “As a compliance measure, subscribers who
+unsubscribe themselves can't be deleted from your list.”</p>
+
+<p>However, provided you are still a subscriber at the point when you contact us,
+on request your details can be permanently removed from the list - please
+<a href="mailto:tictec@mysociety.org">contact us</a> if you would like this to
+happen.</p>
+
+<h2 id="objections">Your right to object</h2>
+
+<p>The General Data Protection Regulation gives you the right to object to our
+processing of your personal information and to ask us to stop processing it.
+To exercise your right to object, please <a href="mailto:tictec@mysociety.org">contact us</a>,
+giving specific reasons why you are objecting to the processing of your personal
+data. These reasons should be based upon your particular situation.</p>
+
+<h2 id="complaints">Your right to complain</h2>
+
+<p>If you believe that we have mishandled your data, you have the right to lodge
+a complaint with the Information Commissioner’s Office.
+<a href="https://ico.org.uk/concerns/handling/">You can report a concern here</a>
+(but do contact us first, so that we can try and help).</p>
+
+<h2 id="us">About us</h2>
+
+<p>TICTeC is run by mySociety, a UK not-for-profit social enterprise. Our
+registered address is:</p>
+
+<p>mySociety<br>
+483 Green Lanes<br>
+London<br>
+N13 4BS<br>
+United Kingdom</p>
+
+<p>…and we can also be contacted at <a href="mailto:hello@mysociety.org">hello@mysociety.org</a>.</p>
+
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/ainow/urls.py
+++ b/ainow/urls.py
@@ -22,7 +22,8 @@ from .views import (
     HomeView,
     SignupView,
     LoginView,
-    ConfirmEmailView
+    ConfirmEmailView,
+    PrivacyView,
 )
 from faq.views import FAQPageView
 
@@ -44,6 +45,8 @@ urlpatterns = [
     # people in immediately after they confirm.
     url(r"^account/confirm_email/(?P<key>\w+)/$", ConfirmEmailView.as_view(), name="account_confirm_email"),
     url(r"^account/", include("account.urls")),
+
+    url(r'^privacy/$', PrivacyView.as_view(), name='privacy'),
 
     url(r'^admin/', admin.site.urls),
     url(r'^markitup/', include('markitup.urls')),

--- a/ainow/views.py
+++ b/ainow/views.py
@@ -122,3 +122,7 @@ class ConfirmEmailView(account.views.ConfirmEmailView):
         if obj.key_expired():
             raise Http404()
         return obj
+
+
+class PrivacyView(TemplateView):
+    template_name = 'ainow/privacy.html'


### PR DESCRIPTION
Fixes #104.

@jacksonj04 (or, I guess, @wrightmartin) I couldn’t get this running locally in a vagrant VM (` Problem installing fixture '/vagrant/ainow/conference/fixtures/sample-data.json': [u"'10:00:00' value has an invalid format. It must be in YYYY-MM-DD HH:MM[:ss[.uuuuuu]][TZ] format."]: (conference.slot:pk=1) field_value was '10:00:00'` during provisioning). Assuming you’ve still got a working TICTeC dev environment, could you try this branch out and let me know if the page itself works? The leyout should be fine – I’ve already tested that bit by copying and pasting into an existing page via the web inspector.