### PR TITLE
Updated packages file with libjpeg62-turbo-dev (fixes #109)

### DIFF
--- a/conf/packages
+++ b/conf/packages
@@ -2,5 +2,5 @@ python-dev
 python-pip
 python-virtualenv
 libpq-dev
-libjpeg8-dev
+libjpeg8-dev | libjpeg62-turbo-dev
 zlib1g-dev


### PR DESCRIPTION
This simply adds the new package so we can install on Stretch.

I've deployed a copy of the TICTeC site, and it appears to be fine, but it may be sensible to have a quick review to confirm this is fine.