### PR TITLE
Use a Debian Stretch based Vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "sagepe/stretch"
 
   # Enable NFS access to the disk
   config.vm.synced_folder "..", "/vagrant"

--- a/conf/packages
+++ b/conf/packages
@@ -2,5 +2,5 @@ python-dev
 python-pip
 python-virtualenv
 libpq-dev
-libjpeg8-dev | libjpeg62-turbo-dev
+libjpeg62-turbo-dev
 zlib1g-dev


### PR DESCRIPTION
This updates the `Vagrantfile` to use an up-to-date box based on Debian Stretch (which is the base OS we use in Production).

Also removes the alternates for the libjpeg dev package in `conf/packages` as this works with our deployment tools but not when fed directly to `apt-get` via `xargs`.