### PR TITLE
Updates to development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ conf/crontab
 .vagrant
 *.pyc
 web/down.html
+tictec.sql

--- a/README.md
+++ b/README.md
@@ -4,14 +4,24 @@ A website for the TICTeC Conference.
 
 ## Local development
 
-This project includes a Vagrantfile to make local development easier.
-Simply run:
+This project includes a `Vagrantfile` to make local development easier.
+
+This includes a trigger that runs `script/bootstrap-dev` on `vagrant up` 
+which will attempt to download up-to-date test data for the environment.
+Note that triggers require Vagrant >= 2.1.0.
+
+It relies on your having key-based SSH access to git.mysociety.org which
+most people working on Tictec should have.
+
+If it encounters a problem, it will halt and output an error message. 
+
+To start work on your local machine, simply run:
 
     $ vagrant up
 
 To get a fully configured vagrant development environment. The code is
 installed into `/vagrant/ainow` inside the VM, and you can run
-the Django dev server with:
+the Django dev server from within the Vagrant machine with:
 
     $ script/server
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ The virtualenv can be sourced with:
 
     $ source ../virtualenv-ainow/bin/activate
 
+### Get a copy of the live data
+
+If you want to mirror the live database to your vagrant dev environment you can
+run `./script/mirror-live-database` from your local machine (_not_ in vagrant!)
+and it will pull down and load the latest version of the data. **Note** This
+will drop your development database and replace it with the live one.
+
 ## Administration
 
 Administration happens through Django's in-built admin interface. For production, this lives at https://tictec.mysociety.org/admin/.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,14 +54,7 @@ Vagrant.configure(2) do |config|
 
     # Create a postgresql user
     sudo -u postgres psql -c "CREATE USER ainow SUPERUSER CREATEDB PASSWORD 'ainow'"
-    # Create a database
-    sudo -u postgres psql -c "CREATE DATABASE ainow"
-    if [ -e tictec.sql ] ; then
-      cat tictec.sql | sudo -u postgres psql ainow
-    else
-      echo '[ERROR] No SQL dump found to import! Please run script/bootstrap-dev from your machine for instructions.' >&2
-      exit 1
-    fi
+    ./script/setup-dev-database
 
     # Install mailcatcher to make dev email development easier
     sudo gem install --no-rdoc --no-ri --version "< 3" mime-types

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,7 +36,7 @@ Vagrant.configure(2) do |config|
 
   # Provision the vagrant box
   config.vm.provision "shell", path: "conf/provisioner.sh", privileged: false
-  config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
     sudo apt-get update
 
     cd /vagrant/ainow
@@ -58,11 +58,12 @@ Vagrant.configure(2) do |config|
     # Copy the general.yml file in place
     cp conf/general.yml-example conf/general.yml
 
+    # We need write access to this.
+    sudo chown vagrant:vagrant /vagrant
+
     # Run post-deploy actions script to update the virtualenv, install the
     # python packages we need, migrate the db and generate the sass etc
     conf/post_deploy_actions.bash
-	
-	sudo chmod -R ugo+rwx /vagrant
 
   SHELL
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,12 @@ Vagrant.configure(2) do |config|
   # For a complete reference, please see the online documentation at
   # https://docs.vagrantup.com.
 
+  # Make sure we've downloaded the latest test data.
+  config.trigger.before [:up] do |trigger|
+    trigger.info = "Running script/bootstrap-dev locally..."
+    trigger.run  = { path: "./script/bootstrap-dev" }
+  end
+
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "sagepe/stretch"
@@ -50,6 +56,12 @@ Vagrant.configure(2) do |config|
     sudo -u postgres psql -c "CREATE USER ainow SUPERUSER CREATEDB PASSWORD 'ainow'"
     # Create a database
     sudo -u postgres psql -c "CREATE DATABASE ainow"
+    if [ -e tictec.sql ] ; then
+      cat tictec.sql | sudo -u postgres psql ainow
+    else
+      echo '[ERROR] No SQL dump found to import! Please run script/bootstrap-dev from your machine for instructions.' >&2
+      exit 1
+    fi
 
     # Install mailcatcher to make dev email development easier
     sudo gem install --no-rdoc --no-ri --version "< 3" mime-types

--- a/script/bootstrap-dev
+++ b/script/bootstrap-dev
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e 
+
+cd "$(dirname "$0")/.."
+
+echo "==> Updating test data..."
+if ssh -o BatchMode=yes git.mysociety.org ls /srv/test-data/tictec/tictec.sql >/dev/null 2>&1 ; then
+  scp git.mysociety.org:/srv/test-data/tictec/tictec.sql .
+  echo '==> Done!'
+else
+  cat <<EOF >&2
+==> Can't download test data - check you have access to the following:
+==>   ssh://git.mysociety.org:/srv/test-data/tictec/tictec.sql
+==> Then either download it yourself or run this script again.
+EOF
+  exit 1
+fi

--- a/script/console
+++ b/script/console
@@ -1,3 +1,9 @@
+#!/bin/bash
+
+set -e 
+
+cd "$(dirname "$0")/.."
+
 virtualenv_dir='../virtualenv-ainow'
 virtualenv_activate="$virtualenv_dir/bin/activate"
 if [ ! -f "$virtualenv_activate" ]

--- a/script/makemigrations
+++ b/script/makemigrations
@@ -1,3 +1,9 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
 virtualenv_dir='../virtualenv-ainow'
 virtualenv_activate="$virtualenv_dir/bin/activate"
 if [ ! -f "$virtualenv_activate" ]

--- a/script/migrate
+++ b/script/migrate
@@ -1,3 +1,9 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
 virtualenv_dir='../virtualenv-ainow'
 virtualenv_activate="$virtualenv_dir/bin/activate"
 if [ ! -f "$virtualenv_activate" ]

--- a/script/mirror-live-database
+++ b/script/mirror-live-database
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [[ "$(whoami)" = "vagrant" ]]; then
+  echo "[ERROR] Please run this script from your local machine, not in vagrant." >&2
+  exit 1
+fi
+
+echo '==> Mirroring live database'
+./script/bootstrap-dev
+vagrant ssh --no-tty -c 'cd /vagrant/ainow && ./script/setup-dev-database'
+echo '==> Done! Live database mirroring complete'

--- a/script/server
+++ b/script/server
@@ -1,3 +1,9 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
 virtualenv_dir='../virtualenv-ainow'
 virtualenv_activate="$virtualenv_dir/bin/activate"
 if [ ! -f "$virtualenv_activate" ]

--- a/script/setup-dev-database
+++ b/script/setup-dev-database
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Drop database
+sudo -u postgres psql -c "DROP DATABASE IF EXISTS ainow"
+
+# Create a database
+sudo -u postgres psql -c "CREATE DATABASE ainow"
+if [ -e tictec.sql ] ; then
+  cat tictec.sql | sudo -u postgres psql ainow
+else
+  echo '[ERROR] No SQL dump found to import! Please run script/bootstrap-dev from your machine for instructions.' >&2
+  exit 1
+fi


### PR DESCRIPTION
This includes a couple of tweaks to @ajparsons recent additions and a new trigger in the `Vagrantfile` to attempt to download test data on a `vagrant up`. This relies on SSH access to git.mysociety org, as well as the local copy of Vagrant being >= 2.1.0.

It would also be possible to include a trigger on `destroy` to ensure that the test data is removed. This would help ensure it was always up-to-date and copies weren't left lying around, although this might prove to be a problem if someone needs to work offline. I'd be interested in views on whether this is a good idea.

This fixes #139.
