### PR TITLE
New page for Environmental Policy

### DIFF
--- a/ainow/templates/ainow/base.html
+++ b/ainow/templates/ainow/base.html
@@ -111,22 +111,14 @@
                     <ul>
                         <li role="presentation"><a href="/">About</a></li>
                         <li role="presentation"><a href="{% static 'guide-2019.pdf' %}">Guide to TICTeC</a></li>
-                        <li role="presentation"><a href="https://www.mysociety.org/code-of-conduct/">Code of Conduct</a></li>
-                        <li role="presentation"><a href="{% url 'privacy' %}">Privacy</a></li>
-                        <li role="presentation"><a href="{% url 'press' %}">Press</a></li>
                         <li role="presentation"><a href="https://www.mysociety.org/research/">Research at mySociety</a></li>
                         <li role="presentation"><a href="https://groups.google.com/forum/?hl=en#%21forum/tictecbymysociety">TICTeC Google Group</a></li>
                     </ul>
                     <ul>
-                        <li role="presentation"><a href="{% url 'schedule2019summary' %}">2019 Paris</a></li>
-                        <li role="presentation"><a href="{% url 'schedule2018summary' %}">2018 Lisbon</a></li>
-                        <li role="presentation"><a href="{% url 'scheduletaipeisummary' %}">TICTeC@Taipei</a></li>
-                        <li role="presentation"><a href="{% url 'schedule2017summary' %}">2017 Florence</a></li>
-                        <li role="presentation"><a href="https://www.mysociety.org/research/tictec-2016/">2016 Barcelona</a></li>
-                        <li role="presentation"><a href="https://www.mysociety.org/research/tictec2015/">2015 London</a></li>
-                    </ul>
-                    <ul>
-                        <li role="presentation"><a href="{% url 'local' %}">TICTeC Local</a></li>
+                        <li role="presentation"><a href="{% url 'press' %}">Press</a></li>
+                        <li role="presentation"><a href="https://www.mysociety.org/code-of-conduct/">Code of Conduct</a></li>
+                        <li role="presentation"><a href="{% url 'privacy' %}">Privacy</a></li>
+                        <li role="presentation"><a href="{% url 'environmental_policy' %}">Environmental Policy</a></li>
                     </ul>
                 </nav>
             </div>

--- a/ainow/templates/ainow/environmental-policy.html
+++ b/ainow/templates/ainow/environmental-policy.html
@@ -1,0 +1,84 @@
+{% extends 'ainow/base.html' %}
+{% load staticfiles %}
+
+{% block title %}Environmental policy{% endblock %}
+
+{% block content %}
+<div class="general-content">
+  <div class="container standard-layout standard-layout--narrow">
+    <div class="general-content__page">
+      <div class="row">
+        <div class="standard-layout__primary-column">
+
+<h1 style="max-width: 14em">Reducing TICTeC’s environmental impact</h1>
+
+<p>TICTeC, our Impacts of Civic Technology Conference, is a global gathering of those interested in building digital civic and democratic tools, and those researching their effectiveness. Learnings at TICTeC have led to the improvement of civic technologies, some of which ultimately improve democracies, strengthen marginalised voices and even save lives.</p>
+
+<p>We run TICTeC every year, and really believe in its benefits; but like all global conferences, it inevitably has an impact on the environment. As with almost every activity, in every sector, the environmental impact versus the good that it does can not be seen in black and white.</p>
+
+<p>We want to reduce and minimise the negative impact of TICTeC 2020 and beyond; and below are some of the things we have already implemented and some things we plan to do.</p>
+
+<h2>Choosing Iceland</h2>
+
+<p>While Iceland isn’t the most accessible of places and international attendees clearly can’t travel there by rail or by boat, there is another important consideration. A large number of  TICTeC attendees come from the United States each year, and Iceland is hundreds of miles closer for them than mainland Europe (where we have previously held TICTeC), making for shorter flights and fewer connections. Also, we expect around 20% of the attendees to be from Iceland itself, so practically speaking hosting TICTeC in Iceland improves the situation for American attendees, although this is offset with the need for all European and other attendees to travel by air.</p>
+
+<p>We’ve chosen to host TICTeC 2020 in Iceland as Reykjavik City Council are pioneers in using open-source digital tools to elicit feedback and engagement from its citizens on council policies, expenditure and projects.</p>
+
+<p>We’re working on TICTeC with several local administrations and organisations in Iceland, so the conference will be a unique occasion for the global community to learn from Iceland’s civic tech and citizen engagement experience, and vice versa.</p>
+
+<h2>Considering carbon offsetting</h2>
+
+<p>A global gathering of people from over 30 countries of course means most attendees will have to fly, therefore emitting carbon into the atmosphere. So we have been looking into carbon offsetting schemes. Truth be told, and as more eloquently put by <a href="https://www.theguardian.com/travel/2019/aug/02/offsetting-carbon-emissions-how-to-travel-options">this journalist</a>, the whole area is quite confusing. At this stage we do not know enough about the effectiveness of these to recommend a particular scheme, but we’re continuing our research into this, as well as reducing our carbon footprints in other areas (see below for some examples). We’d encourage TICTeC attendees to consider doing the same.</p>
+
+<h2>Prioritising environmentally friendly venues</h2>
+
+<p>When selecting venues for TICTeC we prioritise ones that have robust environmental policies in place — like recycling as much material as they can and using renewable energy. The venue for TICTeC 2020 has admirable <a href="https://en.harpa.is/harpa/company/green-policy/">green policies and targets</a>, so we’re happy to be using them. We will continue making this a priority for our future events.</p>
+
+<h2>Vegetarian and vegan food only</h2>
+
+<p>It is widely reported that meat production is detrimental to the planet. So we have decided to only serve vegetarian and vegan food at future TICTeC events, unless we are able to compare the carbon footprints of foods to choose which is more environmentally friendly - for example local meat may have a lower carbon footprint than imported vegetables, but it is difficult for us to know this with resources currently available.</p>
+
+<h2>Maximising in-person contact</h2>
+
+<p>To maximise the purpose/return for attendees’ mileage from around the world, we will host more networking opportunities for TICTeC attendees, so more collaborations and conversations can happen. We all know these conversations are super valuable and wouldn’t necessarily happen if attendees weren’t all in the same room together. When you sign up for TICTeC 2020 you’ll be asked if you’d like to be involved in dedicated networking sessions.</p>
+
+<h2>Encouraging side events</h2>
+
+<p>If you are planning to attend TICTeC, please do consider if you can organise your own events the day(s) before and after TICTeC, rather than asking the same attendees to travel again to another meeting point. This will help reduce carbon emissions from flying. We can help you promote the event if you decide to do this.</p>
+
+<h2>No more conference ‘swag’</h2>
+
+<p>As a charity, we’ve never really had a big budget for conference giveaways, but regardless of this, we think giving out unsolicited branded ‘swag’ is just an unnecessary use of resources (and of course our precious budget) - so we’re not going to do it. This means no more pens, notepads, folders etc - I’m sure if attendees really need these things, they will bring their own. Instead, we’re hoping to offer delegates headshots taken by a professional photographer. Moreover, we could divert expenditure on 'swag' to more worthy things, like helping more attendees and speakers with support grants to improve diversity at the event.</p>
+
+<h2>Going paperless</h2>
+
+<p>In the past, we have given out printed agenda and speaker directory documents at TICTeC events. This time we will not be doing this and will encourage attendees to use the online version instead. We will also send attendees a PDF document of the agenda and speaker directory before the conference, so they can download it onto their phones - this will help those people who might not be able to access data or the internet during the conference.</p>
+
+<p>Any paper we do use (e.g. for name badges, signage etc), will be recycled.</p>
+
+<h2>Reusing</h2>
+
+<p>For years now we have reused conference items each year to save costs and resources - this includes things like name badges, lanyards, roll up banners etc. We will continue doing this and will further encourage attendees to hand back their name badges and lanyards at the end of the conference so they can be reused.</p>
+
+<h2>Providing guidance</h2>
+
+<p>Ahead of the conference we will provide TICTeC attendees with guidance on some of the things they can do during the conference to help reduce their environmental impact.</p>
+
+<h2>Next time</h2>
+
+<p>Recent work by environmental groups have opened our eyes, as it has many others', to the urgency of the situation and while we put these measures in place for 2020's TICTeC long before this, we'll be making bigger changes for 2021. For a start, we will host the conference in a place accessible by rail and sea rather than just air, and we’ll look into options to host it alongside other relevant existing conferences.</p>
+
+<hr>
+
+<p>We know our efforts above are not perfect - and we’re nowhere near to hosting a carbon-neutral event at this stage, but this is just the start of our journey of working out how to do that, so please bear with us and do feel free to make suggestions.</p>
+
+<p>In the meantime, we strongly believe in TICTeC’s mission and think in-person gatherings of those working on and researching civic tech are vital to its development around the world. Ultimately, many civic tech tools are designed to help citizens hold power to account and to shine light on corrupt behaviour and practices, and TICTeC is all about the improvement of these tools so they are more effective. We believe holding power to account is one of the best ways to tackle global challenges such as the climate emergency, so will continue to bring together the global community developing tools that help with this.</p>
+
+<p>You can read more about TICTeC and why we host it over on the <a href="https://tictec.mysociety.org/">event’s website</a>.</p>
+
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/ainow/urls.py
+++ b/ainow/urls.py
@@ -24,6 +24,7 @@ from .views import (
     LoginView,
     ConfirmEmailView,
     PrivacyView,
+    EnvironmentalPolicyView,
     PressView,
 )
 from faq.views import FAQPageView
@@ -48,6 +49,7 @@ urlpatterns = [
     url(r"^account/", include("account.urls")),
 
     url(r'^privacy/$', PrivacyView.as_view(), name='privacy'),
+    url(r'^environmental-policy/$', EnvironmentalPolicyView.as_view(), name='environmental_policy'),
 
     url(r'^press/$', PressView.as_view(), name='press'),
 

--- a/ainow/views.py
+++ b/ainow/views.py
@@ -128,5 +128,9 @@ class PrivacyView(TemplateView):
     template_name = 'ainow/privacy.html'
 
 
+class EnvironmentalPolicyView(TemplateView):
+    template_name = 'ainow/environmental-policy.html'
+
+
 class PressView(TemplateView):
     template_name = 'ainow/press.html'


### PR DESCRIPTION
New page as requested by @Gemmamysoc:

![Screenshot_2019-11-01 Environmental policy TICTeC](https://user-images.githubusercontent.com/739624/68031450-96bfab80-fcb3-11e9-9103-c6b80f758aa5.png)

It’s linked to from the footer of every page. I took the opportunity to remove the laundry list of event links from the footer, so now it’s just all the special / legal / policy links:

![Screenshot_2019-11-01 Home TICTeC](https://user-images.githubusercontent.com/739624/68031460-9a533280-fcb3-11e9-873c-abd382fb20ff.png)
